### PR TITLE
Hide thumbnails

### DIFF
--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -281,7 +281,7 @@ function SettingsIndexScreen({
               detail={settings.compactThumbnailPosition}
               accessory="DisclosureIndicator"
               onPress={() => {
-                const options = ["Left", "Right", "Cancel"];
+                const options = ["None", "Left", "Right", "Cancel"];
                 const cancelButtonIndex = 2;
 
                 showActionSheetWithOptions(

--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -282,7 +282,7 @@ function SettingsIndexScreen({
               accessory="DisclosureIndicator"
               onPress={() => {
                 const options = ["None", "Left", "Right", "Cancel"];
-                const cancelButtonIndex = 2;
+                const cancelButtonIndex = 3;
 
                 showActionSheetWithOptions(
                   {

--- a/slices/settings/settingsSlice.ts
+++ b/slices/settings/settingsSlice.ts
@@ -20,7 +20,7 @@ export interface SettingsState {
   fontSize: number;
   haptics: HapticOptions;
   pushEnabled: string;
-  compactThumbnailPosition: "Left" | "Right";
+  compactThumbnailPosition: "None" | "Left" | "Right";
   compactShowVotingButtons: boolean;
   markReadOnPostView: boolean;
   markReadOnPostImageView: boolean;


### PR DESCRIPTION
This addresses one of the requests in #182. Not much to change since thumbnail container was already checking for Left or Right position setting before rendering.