### PR TITLE
New setting to allow system font to be used instead of bundled font

### DIFF
--- a/Start.tsx
+++ b/Start.tsx
@@ -21,6 +21,7 @@ import { darkTheme } from "./theme/theme";
 import { ThemeOptionsArr, ThemeOptionsMap } from "./theme/themeOptions";
 import Toast from "./components/ui/Toast";
 import merge from "deepmerge";
+import { systemFontSettings } from "./theme/common";
 
 const logError = (e, info) => {
   writeToLog(e.toString());
@@ -42,7 +43,7 @@ function Start() {
   const dispatch = useAppDispatch();
   const accountsLoaded = useAppSelector(selectAccountsLoaded);
 
-  const { theme, themeMatchSystem, themeDark, themeLight, fontSize, isSystemTextSize } = useAppSelector(selectSettings);
+  const { theme, themeMatchSystem, themeDark, themeLight, fontSize, isSystemTextSize, isSystemFont } = useAppSelector(selectSettings);
   const [selectedTheme, setSelectedTheme] = useState<any>(darkTheme);
   const systemColorScheme = useColorScheme();
   const currentTheme = themeMatchSystem ? (systemColorScheme === 'light' ? themeLight : themeDark) : theme;
@@ -122,11 +123,12 @@ function Start() {
           },
         }
         : { fontSizes: getFontScale() }),
+      ( isSystemFont ? systemFontSettings : {}),
     ]));
     // TODO add fallback
     setSelectedTheme(newTheme);
     // ! fontSize has to be here
-  }, [currentTheme, fontSize, getFontScale, isSystemTextSize]);
+  }, [currentTheme, fontSize, getFontScale, isSystemTextSize, isSystemFont]);
 
   if (!loaded) {
     dispatch(loadSettings());

--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -100,7 +100,19 @@ function SettingsIndexScreen({
           />
         </Section>
 
-        <Section header="FONT SIZE" roundedCorners hideSurroundingSeparators>
+        <Section header="FONT" roundedCorners hideSurroundingSeparators>
+        <CCell
+            title="Use System Font"
+            backgroundColor={theme.colors.app.fg}
+            titleTextColor={theme.colors.app.textPrimary}
+            rightDetailColor={theme.colors.app.textSecondary}
+            cellAccessoryView={
+              <Switch
+                value={settings.isSystemFont}
+                onValueChange={(v) => onChange("isSystemFont", v)}
+              />
+            }
+          />
           <CCell
             title="Use System Font Size"
             backgroundColor={theme.colors.app.fg}

--- a/slices/settings/settingsSlice.ts
+++ b/slices/settings/settingsSlice.ts
@@ -19,6 +19,7 @@ export interface SettingsState {
   themeLight: ThemeOptions;
   themeDark: ThemeOptions;
   themeMatchSystem: boolean;
+  isSystemFont: boolean;
   isSystemTextSize: boolean;
   fontSize: number;
   haptics: HapticOptions;
@@ -48,6 +49,7 @@ const initialState: SettingsState = {
   themeLight: "Light",
   themeDark: "Dark",
   themeMatchSystem: false,
+  isSystemFont: false,
   isSystemTextSize: true,
   fontSize: 2,
   haptics: "Medium",

--- a/theme/common.ts
+++ b/theme/common.ts
@@ -46,6 +46,15 @@ export const commonSettings = {
   },
 };
 
+export const systemFontSettings = {
+  fontConfig: {},
+  fonts: {
+    body: undefined, 
+    heading: undefined, 
+    mono: undefined
+  }
+}
+
 interface ICommentChainColors {
   1: string;
   2: string;


### PR DESCRIPTION
Allow system font to be used instead of the included Inter font.

BTW.. I was going to add a menu with some additional font options (probably Roboto, Roboto Condensed, Oswald), but I am not sure where you got or how you generated the OTF format fonts with the 200/600/800 weights that aren't provided by google.

![Screen Shot 2023-07-03 at 2 35 45 PM](https://github.com/Memmy-App/memmy/assets/2118702/c43f63c2-75fa-44f1-83b1-6984f9f70069)
