### PR TITLE
Move link indicator to corner of compact thumbnail

### DIFF
--- a/components/ui/Feed/CompactFeedItem/CompactFeedItemThumbnail.tsx
+++ b/components/ui/Feed/CompactFeedItem/CompactFeedItemThumbnail.tsx
@@ -120,12 +120,17 @@ function CompactFeedItemThumbnail({
                     uri: post.post.thumbnail_url,
                   }}
                 />
-                <View zIndex={1} position="absolute" bottom="1" right="1" style={styles.circle}>
-                  <View zIndex={2} position="absolute" top="1" left="1">
-                    <IconLink size={16} color="#333" />
+                <View
+                  zIndex={1}
+                  position="absolute"
+                  bottom={1}
+                  right={1}
+                  style={styles.circle}
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <IconLink size={16} color="#333" />
                 </View>
-                </View>
-                
               </>
             )) || <IconLink size={40} color={theme.colors.app.textSecondary} />}
           </>
@@ -158,13 +163,13 @@ const styles = StyleSheet.create({
   nsfwIcon: {
     marginLeft: 5,
   },
-  
+
   circle: {
-    height:24,
+    height: 24,
     width: 24,
     borderRadius: 100 / 2,
     backgroundColor: "white",
-    opacity: .8
+    opacity: 0.8,
   },
 });
 

--- a/components/ui/Feed/CompactFeedItem/CompactFeedItemThumbnail.tsx
+++ b/components/ui/Feed/CompactFeedItem/CompactFeedItemThumbnail.tsx
@@ -115,14 +115,17 @@ function CompactFeedItemThumbnail({
               <>
                 <FastImage
                   resizeMode="cover"
-                  style={[styles.image, { opacity: 0.4 }]}
+                  style={[styles.image]}
                   source={{
                     uri: post.post.thumbnail_url,
                   }}
                 />
-                <View zIndex={1} position="absolute">
-                  <IconLink size={40} color={theme.colors.app.textSecondary} />
+                <View zIndex={1} position="absolute" bottom="1" right="1" style={styles.circle}>
+                  <View zIndex={2} position="absolute" top="1" left="1">
+                    <IconLink size={16} color="#333" />
                 </View>
+                </View>
+                
               </>
             )) || <IconLink size={40} color={theme.colors.app.textSecondary} />}
           </>
@@ -154,6 +157,14 @@ const styles = StyleSheet.create({
 
   nsfwIcon: {
     marginLeft: 5,
+  },
+  
+  circle: {
+    height:24,
+    width: 24,
+    borderRadius: 100 / 2,
+    backgroundColor: "white",
+    opacity: .8
   },
 });
 


### PR DESCRIPTION
Subjective thing, but... I found that when there were many Link type posts, the rows in compact mode looked very indistinct.


![IMG_4350](https://github.com/Memmy-App/memmy/assets/2118702/3c16e7c7-3c20-4067-b00f-b010953e2dd3)

I went back to a video I took of Apollo and found that they used an indicator at the bottom right of the thumbnail:

![IMG_4348](https://github.com/Memmy-App/memmy/assets/2118702/e18e74b1-e82b-47c0-94f2-7a213ac9e7f5)

I did something similar here:

![Screen Shot 2023-07-03 at 12 51 04 PM](https://github.com/Memmy-App/memmy/assets/2118702/757ac86f-bb48-4a93-a076-f0bb0761c07c)

I don't actually understand what the units are for top/bottom on the absolute positioning of the View but everything seems to line up so hopefully that will continue to work for all device configurations.