### PR TITLE
Remove unused react-native-appearance package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.10",
     "react-native": "0.71.8",
-    "react-native-appearance": "^0.3.4",
     "react-native-device-info": "^10.6.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-fs": "^2.20.0",


### PR DESCRIPTION
This package is not needed as its functionality has been merged into the react core. I inadvertently added it in #354. The version referenced in the package.json is old and no longer updated.

It didn't really cause any problems with the iOS build at this point, but when I made an Android build out of curiosity, it caused the build to fail since the library hasn't been updated to be built with recent gradle versions.

Wasn't sure if you wanted the yarn.lock and Podfile.lock included (I can add them to PRs if preferred) or you want to regenerate them yourself... Not sure I'm running the exact same version of these package managers as you.