### PR TITLE
Updated toast for reporting a post

### DIFF
--- a/components/ui/post/PostOptionsButton.tsx
+++ b/components/ui/post/PostOptionsButton.tsx
@@ -59,6 +59,7 @@ function CommentSortButton({ postId }: IProps) {
               dispatch(
                 showToast({
                   message: "Report submitted successfully",
+                  duration: 3000,
                   variant: "info",
                 })
               );


### PR DESCRIPTION
Added a duration to the toast confirming a post was reported. It was previously persistent until app restart.