### PR TITLE
fix enabling compact mode in settings doesn't take effect immediately

### DIFF
--- a/src/components/screens/Feed/components/FeedView.tsx
+++ b/src/components/screens/Feed/components/FeedView.tsx
@@ -174,6 +174,7 @@ function FeedView({ feed, community = false, header }: FeedViewProps) {
           </>
         )) || (
           <FlashList
+            key={compactView ? "compact" : "full"}
             ListHeaderComponent={header}
             data={feed.posts}
             renderItem={renderItem}


### PR DESCRIPTION
This should fix #421. 
Since, `<FlashList/>` is not calling `renderItem` again when the `compactView` value is changed, we have to re-render the `<FlashList/>`. To do that, we have to assign a key. The advantage of this solution is, that this will not re-fetch the feed.