### PR TITLE
Add header button to toggle compact view

### DIFF
--- a/src/components/screens/Feed/components/FeedView.tsx
+++ b/src/components/screens/Feed/components/FeedView.tsx
@@ -5,6 +5,10 @@ import { Button, StyleSheet } from "react-native";
 import { FlashList, ListRenderItemInfo } from "@shopify/flash-list";
 import { useNavigation, useScrollToTop } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import {
+  IconArrowsMaximize,
+  IconArrowsMinimize,
+} from "tabler-icons-react-native";
 import FeedItem from "./FeedItem/FeedItem";
 import { useAppDispatch, useAppSelector } from "../../../../../store";
 import {
@@ -12,6 +16,7 @@ import {
   setDropdownVisible,
 } from "../../../../slices/feed/feedSlice";
 import { UseFeed } from "../../../../hooks/feeds/useFeed";
+import { setSetting } from "../../../../slices/settings/settingsActions";
 import { selectSettings } from "../../../../slices/settings/settingsSlice";
 import FeedSortButton from "./FeedSortButton";
 import { Community, FeedOverflowButton } from "./FeedOverflowButton";
@@ -24,6 +29,7 @@ import LoadingView from "../../../common/Loading/LoadingView";
 import LoadingErrorView from "../../../common/Loading/LoadingErrorView";
 import FeedFooter from "./FeedFooter";
 import { removeReadPosts } from "../../../../helpers/LemmyHelpers";
+import HeaderIconButton from "../../../common/Buttons/HeaderIconButton";
 import HideReadFAB from "../../../common/Buttons/HideReadFAB";
 
 interface FeedViewProps {
@@ -87,6 +93,10 @@ function FeedView({ feed, community = false, header }: FeedViewProps) {
 
         return (
           <HStack space={1}>
+            <HeaderIconButton
+              icon={compactView ? <IconArrowsMaximize /> : <IconArrowsMinimize />}
+              onPress={() => dispatch(setSetting({ compactView: !compactView}))}
+            />
             <FeedSortButton
               feed={feed}
               onSortUpdate={() =>

--- a/src/components/screens/Feed/components/FeedView.tsx
+++ b/src/components/screens/Feed/components/FeedView.tsx
@@ -95,7 +95,11 @@ function FeedView({ feed, community = false, header }: FeedViewProps) {
           <HStack space={2}>
             <HeaderIconButton
               icon={
-                compactView ? <IconBaselineDensitySmall /> : <IconBaselineDensityMedium />
+                compactView ? (
+                  <IconBaselineDensitySmall />
+                ) : (
+                  <IconBaselineDensityMedium />
+                )
               }
               onPress={() =>
                 dispatch(setSetting({ compactView: !compactView }))

--- a/src/components/screens/Feed/components/FeedView.tsx
+++ b/src/components/screens/Feed/components/FeedView.tsx
@@ -6,8 +6,8 @@ import { FlashList, ListRenderItemInfo } from "@shopify/flash-list";
 import { useNavigation, useScrollToTop } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
-  IconArrowsMaximize,
-  IconArrowsMinimize,
+  IconBaselineDensitySmall,
+  IconBaselineDensityMedium,
 } from "tabler-icons-react-native";
 import FeedItem from "./FeedItem/FeedItem";
 import { useAppDispatch, useAppSelector } from "../../../../../store";
@@ -92,10 +92,10 @@ function FeedView({ feed, community = false, header }: FeedViewProps) {
         }
 
         return (
-          <HStack space={1}>
+          <HStack space={2}>
             <HeaderIconButton
               icon={
-                compactView ? <IconArrowsMaximize /> : <IconArrowsMinimize />
+                compactView ? <IconBaselineDensitySmall /> : <IconBaselineDensityMedium />
               }
               onPress={() =>
                 dispatch(setSetting({ compactView: !compactView }))

--- a/src/components/screens/Feed/components/FeedView.tsx
+++ b/src/components/screens/Feed/components/FeedView.tsx
@@ -94,8 +94,12 @@ function FeedView({ feed, community = false, header }: FeedViewProps) {
         return (
           <HStack space={1}>
             <HeaderIconButton
-              icon={compactView ? <IconArrowsMaximize /> : <IconArrowsMinimize />}
-              onPress={() => dispatch(setSetting({ compactView: !compactView}))}
+              icon={
+                compactView ? <IconArrowsMaximize /> : <IconArrowsMinimize />
+              }
+              onPress={() =>
+                dispatch(setSetting({ compactView: !compactView }))
+              }
             />
             <FeedSortButton
               feed={feed}


### PR DESCRIPTION
Fixes https://github.com/Memmy-App/memmy/issues/508

Default view (non-compact). Note the button acts like the other buttons where it shows the current view (in this case, the medium icon) and clicking it switches to the other view.

![Simulator Screenshot - iPhone 14 Pro - 2023-07-09 at 19 52 49](https://github.com/Memmy-App/memmy/assets/14875982/0898112c-0526-49e7-af58-ed84999c725a)

After clicking the icon, the app switches to compact view.

![Simulator Screenshot - iPhone 14 Pro - 2023-07-09 at 19 52 57](https://github.com/Memmy-App/memmy/assets/14875982/b4362ed5-e7b3-4d65-8d5b-9c404821e606)

Clicking again shows the default view (non-compact).