### PR TITLE
fix post menu view & cancel behaviour. fixes #577 and #511

### DIFF
--- a/src/components/screens/Post/components/PostOptionsButton.tsx
+++ b/src/components/screens/Post/components/PostOptionsButton.tsx
@@ -4,7 +4,6 @@ import { useActionSheet } from "@expo/react-native-action-sheet";
 import { IconDots } from "tabler-icons-react-native";
 import { Alert } from "react-native";
 import { useAppDispatch } from "../../../../../store";
-import { commentSortOptions } from "../../../../types/CommentSortOptions";
 import { lemmyAuthToken, lemmyInstance } from "../../../../LemmyInstance";
 import { showToast } from "../../../../slices/toast/toastSlice";
 import { writeToLog } from "../../../../helpers/LogHelper";
@@ -20,11 +19,12 @@ function CommentSortButton({ postId }: IProps) {
   const dispatch = useAppDispatch();
 
   const onPress = () => {
-    const cancelButtonIndex = commentSortOptions.length;
+    const options = ["Report Post", "Cancel"];
+    const cancelButtonIndex = options.indexOf("Cancel");
 
     showActionSheetWithOptions(
       {
-        options: ["Report Post", "Cancel"],
+        options,
         cancelButtonIndex,
         userInterfaceStyle: theme.config.initialColorMode,
       },


### PR DESCRIPTION
fixes #577 and maybe #511 

## PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [x] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [x] Your changes are free of any typescript errors
- [x] You've tested your changes

## Summary

You can now also use the 'clickAway' method to close the menu just like the comments menu

## Screenshots


https://github.com/Memmy-App/memmy/assets/50131232/316aed34-7160-4820-b837-6506fa993eef




## Test Plan

1. Open the app
2. Open a post of your choice
3. click the 3 vertical dots at the top right (posts menu)
4. click anywhere where there is no buttons
5. menu should close

```