### PR TITLE
Fix white flash after splashscreen

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,6 +7,9 @@ import { useFonts } from "expo-font";
 import { enableFreeze } from "react-native-screens";
 import store from "./store";
 import Start from "./Start";
+import * as SplashScreen from "expo-splash-screen";
+
+SplashScreen.preventAutoHideAsync();
 
 export default function App() {
   enableFreeze(true);
@@ -35,6 +38,8 @@ export default function App() {
   if (!fontsLoaded) {
     return null;
   }
+
+  SplashScreen.hideAsync();
 
   return (
     <Provider store={store}>


### PR DESCRIPTION
This should prevent the white flash after the splashscreen. Currently, the splashscreen disappears while we are still loading fonts. If fonts are not loaded, we return null, but because the splashscreen has already disappeared we get a white screen.

Disabling the auto hiding of the splashscreen then hiding it manually once fonts are loaded gets rid of this issue.