### PR TITLE
implement concealing username with face id protection

### DIFF
--- a/ios/Memmy/Info.plist
+++ b/ios/Memmy/Info.plist
@@ -228,5 +228,7 @@
 	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSFaceIDUsageDescription</key>
+    <string>Enabling Face ID allows you quick and secure access to your account.</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -116,6 +116,8 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (12.3.0):
     - ExpoModulesCore
+  - ExpoLocalAuthentication (13.4.1):
+    - ExpoModulesCore
   - ExpoLocalization (14.3.0):
     - ExpoModulesCore
   - ExpoMailComposer (12.1.1):
@@ -664,6 +666,7 @@ DEPENDENCIES:
   - ExpoDevice (from `../node_modules/expo-device/ios`)
   - ExpoImagePicker (from `../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
+  - ExpoLocalAuthentication (from `../node_modules/expo-local-authentication/ios`)
   - ExpoLocalization (from `../node_modules/expo-localization/ios`)
   - ExpoMailComposer (from `../node_modules/expo-mail-composer/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
@@ -824,6 +827,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-image-picker/ios"
   ExpoKeepAwake:
     :path: "../node_modules/expo-keep-awake/ios"
+  ExpoLocalAuthentication:
+    :path: "../node_modules/expo-local-authentication/ios"
   ExpoLocalization:
     :path: "../node_modules/expo-localization/ios"
   ExpoMailComposer:
@@ -976,6 +981,7 @@ SPEC CHECKSUMS:
   ExpoDevice: e0bebf68f978b3d353377ce42e73c20c0a070215
   ExpoImagePicker: 270dea232b3a072d981dd564e2cafc63a864edb1
   ExpoKeepAwake: be4cbd52d9b177cde0fd66daa1913afa3161fc1d
+  ExpoLocalAuthentication: bd9d9037a96a11ccc456e327ddb404df02da10ca
   ExpoLocalization: be37fdd0b5930c6a49cd307b4542f4b426d6134c
   ExpoMailComposer: 0085b258d00ba40664f7acb40d96042b29a1da7d
   ExpoModulesCore: adc9baa017bb42c93b08eea8ac7e222cb277262b

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "expo-font": "~11.1.1",
     "expo-image-picker": "~14.1.1",
     "expo-linking": "~5.0.0",
+    "expo-local-authentication": "~13.4.1",
     "expo-localization": "^14.3.0",
     "expo-mail-composer": "~12.1.1",
     "expo-media-library": "~15.2.3",

--- a/src/components/screens/Feed/components/FeedHeaderDropdown.tsx
+++ b/src/components/screens/Feed/components/FeedHeaderDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { HStack, Icon, Pressable, Text, useTheme, VStack } from "native-base";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Ionicons } from "@expo/vector-icons";
@@ -16,6 +16,8 @@ import {
   selectAccounts,
   selectCurrentAccount,
 } from "../../../../slices/accounts/accountsSlice";
+import { selectSettings } from "../../../../slices/settings/settingsSlice";
+import { concealableText } from "../../../../helpers/TextHelper";
 
 interface HeaderDropdownProps {
   enabled: boolean;
@@ -25,12 +27,18 @@ function FeedHeaderDropdown({ enabled }: HeaderDropdownProps) {
   const { dropdownVisible } = useAppSelector(selectFeed);
   const currentAccount = useAppSelector(selectCurrentAccount);
   const accounts = useAppSelector(selectAccounts);
+  const { hideUsername } = useAppSelector(selectSettings);
 
   const dispatch = useAppDispatch();
 
   const theme = useTheme();
 
   const timer = useSharedValue(0);
+
+  const visibleAccount = useMemo(
+    () => currentAccount || accounts[0],
+    [currentAccount, accounts]
+  );
 
   useEffect(() => {
     timer.value = withTiming(dropdownVisible ? 1 : 0, { duration: 300 });
@@ -50,11 +58,9 @@ function FeedHeaderDropdown({ enabled }: HeaderDropdownProps) {
       <HStack justifyContent="center" alignItems="center" space="3">
         <VStack justifyContent="center" alignItems="center">
           <Text fontSize="16" fontWeight="bold">
-            {currentAccount ? currentAccount.username : accounts[0].username}
+            {concealableText(visibleAccount.username, hideUsername)}
           </Text>
-          <Text fontSize="12">
-            {currentAccount ? currentAccount.instance : accounts[0].instance}
-          </Text>
+          <Text fontSize="12">{visibleAccount.instance}</Text>
         </VStack>
         <Animated.View style={caretRotation}>
           <Icon

--- a/src/components/screens/Feed/components/FeedHeaderDropdownDrawer.tsx
+++ b/src/components/screens/Feed/components/FeedHeaderDropdownDrawer.tsx
@@ -16,10 +16,13 @@ import { Account } from "../../../../types/Account";
 import CCell from "../../../common/Table/CCell";
 import CSection from "../../../common/Table/CSection";
 import CTable from "../../../common/Table/CTable";
+import { selectSettings } from "../../../../slices/settings/settingsSlice";
+import { concealableText } from "../../../../helpers/TextHelper";
 
 function FeedHeaderDropdownDrawer() {
   const { dropdownVisible } = useAppSelector(selectFeed);
   const accounts = useAppSelector(selectAccounts);
+  const { hideUsername } = useAppSelector(selectSettings);
 
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -54,7 +57,10 @@ function FeedHeaderDropdownDrawer() {
                   <CCell
                     key={account.username}
                     cellStyle="Basic"
-                    title={`${account.username}@${account.instance}`}
+                    title={`${concealableText(
+                      account.username,
+                      hideUsername
+                    )}@${account.instance}`}
                     accessory="DisclosureIndicator"
                     onPress={() => onAccountPress(account)}
                   />

--- a/src/components/screens/Settings/Account/EditAccountScreen.tsx
+++ b/src/components/screens/Settings/Account/EditAccountScreen.tsx
@@ -21,6 +21,8 @@ import { useAppDispatch, useAppSelector } from "../../../../../store";
 import CCell from "../../../common/Table/CCell";
 import { showToast } from "../../../../slices/toast/toastSlice";
 import ILemmyServer from "../../../../types/lemmy/ILemmyServer";
+import { selectSettings } from "../../../../slices/settings/settingsSlice";
+import { concealableText } from "../../../../helpers/TextHelper";
 
 function EditAccountScreen({
   route,
@@ -47,6 +49,7 @@ function EditAccountScreen({
   const dispatch = useAppDispatch();
 
   const accounts = useAppSelector(selectAccounts);
+  const { hideUsername } = useAppSelector(selectSettings);
 
   const headerRight = () => (
     <Button
@@ -224,7 +227,10 @@ function EditAccountScreen({
                 }}
                 placeholderTextColor={theme.colors.app.textSecondary}
                 placeholder={t("Username")}
-                value={form.username}
+                value={concealableText(
+                  form.username,
+                  edit.current && hideUsername
+                )}
                 onChangeText={(text) => onFormChange("username", text)}
                 autoCapitalize="none"
                 autoCorrect={false}

--- a/src/components/screens/UserProfile/components/ProfileHeader.tsx
+++ b/src/components/screens/UserProfile/components/ProfileHeader.tsx
@@ -14,6 +14,9 @@ import dayjs from "dayjs";
 import { getBaseUrl } from "../../../../helpers/LinkHelper";
 import { UseProfile } from "../../../../hooks/profile/useProfile";
 import { getCakeDay } from "../../../../helpers/TimeHelper";
+import { useAppSelector } from "../../../../../store";
+import { selectSettings } from "../../../../slices/settings/settingsSlice";
+import { concealableText } from "../../../../helpers/TextHelper";
 
 interface IProps {
   profile: UseProfile;
@@ -21,6 +24,8 @@ interface IProps {
 
 function ProfileHeader({ profile }: IProps) {
   const theme = useTheme();
+
+  const { hideUsername } = useAppSelector(selectSettings);
 
   if (!profile.profile) return null;
 
@@ -49,7 +54,7 @@ function ProfileHeader({ profile }: IProps) {
           )}
           <VStack>
             <Text fontWeight="semibold" fontSize="2xl">
-              {profile.profile.person.name}
+              {concealableText(profile.profile.person.name, hideUsername)}
             </Text>
             <Text fontSize="lg">
               @{getBaseUrl(profile.profile.person.actor_id)}

--- a/src/helpers/TextHelper.ts
+++ b/src/helpers/TextHelper.ts
@@ -31,3 +31,6 @@ export const truncateCompactFeedItem = (text: string): string => {
 
   return `${text.slice(0, 60)}...`;
 };
+
+export const concealableText = (text: string, isConcealed: boolean) =>
+  !isConcealed ? text : "#########";

--- a/src/hooks/app/useFaceId.ts
+++ b/src/hooks/app/useFaceId.ts
@@ -1,0 +1,26 @@
+import * as LocalAuthentication from "expo-local-authentication";
+import { LocalAuthenticationResult } from "expo-local-authentication/src/LocalAuthentication.types";
+
+const useFaceId = () => {
+  const authenticateFaceId = async () => {
+    const isCompatible = await LocalAuthentication.hasHardwareAsync();
+
+    if (isCompatible) {
+      const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+
+      if (isEnrolled) {
+        return LocalAuthentication.authenticateAsync();
+      }
+    }
+    // no fallback available yet
+    return Promise.resolve<LocalAuthenticationResult>({
+      success: true,
+    });
+  };
+
+  return {
+    authenticateFaceId,
+  };
+};
+
+export default useFaceId;

--- a/src/plugins/i18n/locales/de.json
+++ b/src/plugins/i18n/locales/de.json
@@ -146,6 +146,11 @@
       "credentials": {
         "header": "Server Anmeldedaten",
         "footer": "Anmeldedaten für den Server mit dem du dich verbinden möchtest"
+      },
+      "other": {
+        "header": "Weitere Einstellungen",
+        "hideUsername": "Eigenen Benutzernamen ausblenden",
+        "hideUsernameFooter": "Wenn Face ID aktiviert ist musst du dich zum deaktiveren authentifizieren"
       }
     }
   },
@@ -240,6 +245,9 @@
   },
   "imageView": {
     "dialogDesc": "Bild wird heruntergeladen..."
+  },
+  "faceId": {
+    "failed": "Face ID authentifizierung fehlgeschlagen"
   },
   "Feed": "Feed",
   "Comments": "Kommentare",

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -153,6 +153,11 @@
       "credentials": {
         "header": "Server Credentials",
         "footer": "Credentials for the server you are connecting to"
+      },
+      "other": {
+        "header": "Other",
+        "hideUsername": "Hide My Username",
+        "hideUsernameFooter": "If Face ID is active you need to authenticate to disable it"
       }
     }
   },
@@ -253,6 +258,9 @@
   },
   "imageView": {
     "dialogDesc": "Downloading image..."
+  },
+  "faceId": {
+    "failed": "Face ID authentication failed"
   },
   "Feed": "Feed",
   "Comments": "Comments",

--- a/src/slices/settings/settingsSlice.ts
+++ b/src/slices/settings/settingsSlice.ts
@@ -39,6 +39,7 @@ export interface SettingsState {
   appIcon: string;
   showCommentActions: boolean;
   useDefaultBrowser: boolean;
+  hideUsername: boolean;
 }
 
 const initialState: SettingsState = {
@@ -74,6 +75,7 @@ const initialState: SettingsState = {
   appIcon: "purple",
   showCommentActions: true,
   useDefaultBrowser: false,
+  hideUsername: false,
 };
 
 const settingsSlice = createSlice({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,6 +5494,13 @@ expo-linking@~5.0.0:
     qs "^6.11.0"
     url-parse "^1.5.9"
 
+expo-local-authentication@~13.4.1:
+  version "13.4.1"
+  resolved "https://registry.yarnpkg.com/expo-local-authentication/-/expo-local-authentication-13.4.1.tgz#908516d395530f6895d7980009e4c85cdcff5327"
+  integrity sha512-FWTUkMNo9aDT3cg02SWAcSFjTiDu20izhCn5CGwdtFNCBpPQUD0BJ/czhjrIFE70teMzE5wZUdbJuSKYonUaWA==
+  dependencies:
+    invariant "^2.2.4"
+
 expo-localization@^14.3.0:
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/expo-localization/-/expo-localization-14.3.0.tgz#a7614114079658000f46c7e3029703c8508e0678"
@@ -9833,6 +9840,7 @@ rtl-detect@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/rtl-detect/-/rtl-detect-1.0.4.tgz#40ae0ea7302a150b96bc75af7d749607392ecac6"
   integrity sha512-EBR4I2VDSSYr7PkBmFy04uhycIpDKp+21p/jARYXlCSjQksTBQcJ0HFUPOO79EPPH5JS6VAhiIQbycf0O3JAxQ==
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -11077,11 +11085,6 @@ vlq@^1.0.0:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
-void-elements@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
-  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
-  
 vm2@^3.9.17:
   version "3.9.19"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
@@ -11089,6 +11092,11 @@ vm2@^3.9.17:
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 walker@^1.0.7:
   version "1.0.8"


### PR DESCRIPTION
fixes #657 

This allows the user to conceal their username to just display "#########" and if Face ID is active it it checked upon tying to disable this settings.

Its also very useful for development screenshot 🚀 

<img width="435" alt="image" src="https://github.com/Memmy-App/memmy/assets/50131232/25b45403-4b8f-4bdd-8678-2da34614d744">
<img width="435" alt="image" src="https://github.com/Memmy-App/memmy/assets/50131232/61a2e1bc-b45b-4cb9-b4bc-dd235763ed34">
<img width="435" alt="image" src="https://github.com/Memmy-App/memmy/assets/50131232/a33e88a5-0703-40a0-8bb7-d127c36964fc">
<img width="435" alt="image" src="https://github.com/Memmy-App/memmy/assets/50131232/de9a1c7d-131c-476c-a1f3-8eb78cee0f14">

<img width="435" alt="image" src="https://github.com/Memmy-App/memmy/assets/50131232/cd587f6b-f495-4cda-b44f-70c68132be4e">


https://github.com/Memmy-App/memmy/assets/50131232/c89ac16e-ea57-4218-b9c5-619658b0a762
