### PR TITLE
delete image after share

### DIFF
--- a/src/components/common/ImageViewer/ImageViewFooter.tsx
+++ b/src/components/common/ImageViewer/ImageViewFooter.tsx
@@ -24,17 +24,27 @@ function ImageViewFooter({ source, visible }: ImageViewFooterProps) {
   const onSave = async () => {
     onGenericHapticFeedback();
     setDownloading(true);
-    await downloadAndSaveImage(source);
-    setDownloading(false);
+
+    try {
+      await downloadAndSaveImage(source);
+      setDownloading(false);
+    } catch (e) {
+      setDownloading(false);
+    }
   };
 
   const onShare = async () => {
     setDownloading(true);
-    await shareLink({
-      link: source,
-      isImage: true,
-      callback: () => setDownloading(false),
-    });
+
+    try {
+      await shareLink({
+        link: source,
+        isImage: true,
+        callback: () => setDownloading(false),
+      });
+    } catch (e) {
+      setDownloading(false);
+    }
   };
 
   return (

--- a/src/helpers/ImageHelper.ts
+++ b/src/helpers/ImageHelper.ts
@@ -26,6 +26,18 @@ export const downloadImage = async (src: string): Promise<string | boolean> => {
   }
 };
 
+export const deleteImage = async (uri: string): Promise<boolean> => {
+  try {
+    await FileSystem.deleteAsync(uri);
+    console.log("Image deleted.");
+    return true;
+  } catch (e) {
+    writeToLog("Error deleting file.");
+    writeToLog(e.toString());
+    return false;
+  }
+};
+
 const downloadAndSaveImage = async (src: string): Promise<boolean> => {
   const { status } = await Permissions.askAsync(Permissions.MEDIA_LIBRARY);
 

--- a/src/helpers/ImageHelper.ts
+++ b/src/helpers/ImageHelper.ts
@@ -54,6 +54,7 @@ const downloadAndSaveImage = async (src: string): Promise<boolean> => {
 const saveImage = async (filePath: string) => {
   try {
     await MediaLibrary.createAssetAsync(filePath);
+    deleteImage(filePath).then();
   } catch (e) {
     writeToLog("Error saving image.");
     writeToLog(e.toString());

--- a/src/helpers/ShareHelper.ts
+++ b/src/helpers/ShareHelper.ts
@@ -1,6 +1,6 @@
 import Share, { ShareOptions } from "react-native-share";
 import { Alert } from "react-native";
-import { downloadImage } from "./ImageHelper";
+import { deleteImage, downloadImage } from "./ImageHelper";
 import { onGenericHapticFeedback } from "./HapticFeedbackHelpers";
 
 interface ShareLinkOptions {
@@ -24,6 +24,8 @@ export const shareLink = async ({
     title,
   };
 
+  let uri: string;
+
   if (isImage) {
     const res = await downloadImage(link);
 
@@ -32,7 +34,7 @@ export const shareLink = async ({
       return;
     }
 
-    const uri = res as string;
+    uri = res as string;
 
     options = {
       filename: uri.split("/").pop(),
@@ -51,8 +53,13 @@ export const shareLink = async ({
     };
   }
 
+  const after = () => {
+    if (callback) callback();
+    if (isImage) deleteImage(uri);
+  };
+
   try {
-    Share.open(options).then(() => callback && callback());
+    Share.open(options).then(() => after());
   } catch {
     /* empty */
   }


### PR DESCRIPTION
### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [x] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [x] Your changes are free of any typescript errors
- [x] You've tested your changes

### Summary

If the network times our or something else happens to an image download, currently the image download dialog does not disappear after that timeout. This fixes those issues. Also, images are deleted from the filesystem after being shared or after being added to the camera roll.

