### PR TITLE
fix link wizard translation

### DIFF
--- a/src/components/common/KeyboardAccessory.tsx
+++ b/src/components/common/KeyboardAccessory.tsx
@@ -61,11 +61,11 @@ function KeyboardAccessory({
   const onLinkPress = async () => {
     Alert.prompt(
       t("Link"),
-      t("toast.message.enterUrl"),
+      t("toast.enterUrl"),
       (link) => {
         Alert.prompt(
           t("Label"),
-          t("toast.message.enterLabel"),
+          t("toast.enterLabel"),
           (label) => {
             setText(replace(`[${label}](${link})`));
           },


### PR DESCRIPTION
Super basic, was not using the correct localization key for the link wizard prompts.