### PR TITLE
Cancelling image picking causes Alert "Imgur upload failed" [fixes #628]

### DIFF
--- a/src/components/common/KeyboardAccessory.tsx
+++ b/src/components/common/KeyboardAccessory.tsx
@@ -14,6 +14,7 @@ import LoadingModal from "./Loading/LoadingModal";
 import uploadToImgur from "../../helpers/ImgurHelper";
 import { writeToLog } from "../../helpers/LogHelper";
 import IconButtonWithText from "./IconButtonWithText";
+import { ErrorCause } from "../../types/ErrorCause";
 
 function KeyboardAccessory({
   setText,
@@ -99,16 +100,23 @@ function KeyboardAccessory({
 
     try {
       path = await selectImage();
-    } catch (e) {
+    } catch (e: unknown) {
+      const err = e as Error;
       writeToLog("Error getting images.");
       writeToLog(e.toString());
 
-      if (e.toString() === "permissions") {
-        Alert.alert(
-          t("alert.title.permissionsError"),
-          t("alert.message.allowCameraRoll")
-        );
-        return;
+      switch (err.cause) {
+        case ErrorCause.NO_PERMISSION:
+          Alert.alert(
+            t("alert.title.permissionsError"),
+            t("alert.message.allowCameraRoll")
+          );
+          return;
+        case ErrorCause.USER_CANCEL:
+          // just close it, no notice
+          return;
+        default:
+        // continue
       }
     }
 
@@ -118,13 +126,13 @@ function KeyboardAccessory({
 
     try {
       imgurLink = await uploadToImgur(path);
-    } catch (e) {
+    } catch (e: unknown) {
       setUploading(false);
 
       writeToLog("Error uploading image.");
       writeToLog(e.toString());
 
-      Alert.alert("Error uploading to Imgur.");
+      Alert.alert(t("alert.message.imgurUploadError"));
       return;
     }
 
@@ -136,6 +144,7 @@ function KeyboardAccessory({
 
   return (
     <InputAccessoryView nativeID="accessory">
+      <LoadingModal loading={uploading} />
       <HStack
         backgroundColor={theme.colors.app.bg}
         height={12}
@@ -164,7 +173,6 @@ function KeyboardAccessory({
           icon={<IconPhoto size={24} color={theme.colors.app.accent} />}
         />
       </HStack>
-      <LoadingModal loading={uploading} />
     </InputAccessoryView>
   );
 }

--- a/src/helpers/ImageHelper.ts
+++ b/src/helpers/ImageHelper.ts
@@ -12,6 +12,7 @@ import { Alert, Dimensions } from "react-native";
 import i18n from "../plugins/i18n/i18n";
 import { writeToLog } from "./LogHelper";
 import { ExtensionType, getLinkInfo } from "./LinkHelper";
+import { ErrorCause } from "../types/ErrorCause";
 
 export const downloadImage = async (src: string): Promise<string | boolean> => {
   const fileName = src.split("/").pop();
@@ -78,12 +79,12 @@ export const selectImage = async (): Promise<string> => {
     });
 
     if (res.canceled) {
-      throw Error("cancelled");
+      throw Error("cancelled", { cause: ErrorCause.USER_CANCEL });
     }
 
     return res.assets[0].uri;
   }
-  throw Error("permissions");
+  throw Error("permissions", { cause: ErrorCause.NO_PERMISSION });
 };
 
 export const preloadImages = async (posts: PostView[]): Promise<void> => {

--- a/src/types/ErrorCause.ts
+++ b/src/types/ErrorCause.ts
@@ -1,0 +1,4 @@
+export enum ErrorCause {
+  NO_PERMISSION = "no_permission",
+  USER_CANCEL = "user_cancel",
+}


### PR DESCRIPTION
when opening the image picker in a new post or a new comment and then clicking cancel the error alert no long appears

### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [ ] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [X] Your changes are free of any typescript errors
- [X] You've tested your changes

### Summary

When opening the image picker in a new post or a new comment and then clicking cancel the error alert no long appears

### Screenshots

https://github.com/Memmy-App/memmy/assets/50131232/a05393e3-80f1-4925-acb7-fcdbbd9ebfb4

https://github.com/Memmy-App/memmy/assets/50131232/4329c446-c136-4b79-8f1c-9e0aac1c2ac7

### Test Plan

#### New Post

1. Open lemmy app
2. Navigate to any community where you have a `+ Post` Button available
3. Press the `+ Post` Button
4. Click the image icon at the bottom right to open the img picker
5. Press `Cancel` at the top left
6. There should be NO alert anymore

#### New Comment

1. Open lemmy app
2. Open any Post where you can comment on
3. Press the `+Comment` Button
4. Click the image icon at the bottom right to open the img picker
5. Press `Cancel` at the top left
6. There should be NO alert anymore

--------

fixes #628 