### PR TITLE
Fix: Filtering of NSFW from the feed now checks for community NSFW flag

### DIFF
--- a/src/helpers/LemmyHelpers.ts
+++ b/src/helpers/LemmyHelpers.ts
@@ -23,7 +23,7 @@ export const removeDuplicatePosts = (
   );
 
 export const removeNsfwPosts = (list: PostView[]) =>
-  list.filter((p) => !p.post.nsfw);
+  list.filter((p) => !p.post.nsfw && !p.community.nsfw);
 
 export const getCommunityFullName = (community: CommunityView) =>
   `${community?.community?.name}@${getBaseUrl(community?.community?.actor_id)}`;


### PR DESCRIPTION
Should have been doing this from the start, but it is rather confusing how Lemmy handles this. Anyway, we now filter out NSFW posts based off of both the community flag and the post flag.