### PR TITLE
Fix swipe to vote change throws you back to the root settings page (#810)

### DIFF
--- a/Stack.tsx
+++ b/Stack.tsx
@@ -370,6 +370,7 @@ function SettingsStackScreen() {
       screenOptions={{
         freezeOnBlur: true,
       }}
+      id="SettingsStackNavigator"
     >
       {SettingsScreens(SettingsStack)}
     </SettingsStack.Navigator>

--- a/ios/Memmy.xcodeproj/project.pbxproj
+++ b/ios/Memmy.xcodeproj/project.pbxproj
@@ -1462,8 +1462,14 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited)  ";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)  ";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -1517,8 +1523,14 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "$(inherited)  ";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)  ";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/src/components/screens/Settings/Appearance/AppearanceScreen.tsx
+++ b/src/components/screens/Settings/Appearance/AppearanceScreen.tsx
@@ -2,7 +2,7 @@ import { TableView } from "@gkasdorf/react-native-tableview-simple";
 import Slider from "@react-native-community/slider";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Box, HStack, ScrollView, Text, useTheme } from "native-base";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { LayoutAnimation, StyleSheet, Switch } from "react-native";
 import { useTranslation } from "react-i18next";
 import { ContextMenuButton } from "react-native-ios-context-menu";
@@ -28,24 +28,9 @@ function AppearanceScreen({ navigation }: IProps) {
   const dispatch = useAppDispatch();
   const theme = useTheme();
 
-  const [swipeToVoteBuffer, setSwipeToVoteBuffer] = useState<boolean>(
-    settings.swipeToVote
-  );
-
   const onChange = (key: string, value: any) => {
     dispatch(setSetting({ [key]: value }));
   };
-
-  const handleNavigationBlur = () => {
-    onChange("swipeToVote", swipeToVoteBuffer);
-  };
-
-  useEffect(() => {
-    navigation.addListener("blur", handleNavigationBlur);
-    return () => {
-      navigation.removeListener("blur", handleNavigationBlur);
-    };
-  });
 
   const selectedFontWeight =
     Object.keys(FontWeightMap).find(

--- a/src/components/screens/Settings/Appearance/AppearanceScreen.tsx
+++ b/src/components/screens/Settings/Appearance/AppearanceScreen.tsx
@@ -2,7 +2,7 @@ import { TableView } from "@gkasdorf/react-native-tableview-simple";
 import Slider from "@react-native-community/slider";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Box, HStack, ScrollView, Text, useTheme } from "native-base";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { LayoutAnimation, StyleSheet, Switch } from "react-native";
 import { useTranslation } from "react-i18next";
 import { ContextMenuButton } from "react-native-ios-context-menu";
@@ -28,9 +28,24 @@ function AppearanceScreen({ navigation }: IProps) {
   const dispatch = useAppDispatch();
   const theme = useTheme();
 
+  const [swipeToVoteBuffer, setSwipeToVoteBuffer] = useState<boolean>(
+    settings.swipeToVote
+  );
+
   const onChange = (key: string, value: any) => {
     dispatch(setSetting({ [key]: value }));
   };
+
+  const handleNavigationBlur = () => {
+    onChange("swipeToVote", swipeToVoteBuffer);
+  };
+
+  useEffect(() => {
+    navigation.addListener("blur", handleNavigationBlur);
+    return () => {
+      navigation.removeListener("blur", handleNavigationBlur);
+    };
+  });
 
   const selectedFontWeight =
     Object.keys(FontWeightMap).find(
@@ -189,7 +204,7 @@ function AppearanceScreen({ navigation }: IProps) {
 
         <CSection
           header={t("settings.appearance.gestures.header")}
-          footer="Disabling swipe to vote will allow for full-screen swipe gestures."
+          footer="Disabling swipe to vote will allow for full-screen swipe gestures." // TODO: translate!
         >
           <CCell
             cellStyle="Basic"
@@ -206,14 +221,14 @@ function AppearanceScreen({ navigation }: IProps) {
           />
           <CCell
             cellStyle="Basic"
-            title="Swipe to Vote"
+            title="Swipe to Vote" // TODO: translate
             backgroundColor={theme.colors.app.fg}
             titleTextColor={theme.colors.app.textPrimary}
             rightDetailColor={theme.colors.app.textSecondary}
             cellAccessoryView={
               <Switch
-                value={settings.swipeToVote}
-                onValueChange={(v) => onChange("swipeToVote", v)}
+                value={swipeToVoteBuffer}
+                onValueChange={(v) => setSwipeToVoteBuffer(v)}
               />
             }
           />

--- a/src/components/screens/Settings/General/GeneralSettingsScreen.tsx
+++ b/src/components/screens/Settings/General/GeneralSettingsScreen.tsx
@@ -1,9 +1,10 @@
 import { TableView } from "@gkasdorf/react-native-tableview-simple";
 import { ScrollView, useTheme } from "native-base";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Switch } from "react-native";
 import { ContextMenuButton } from "react-native-ios-context-menu";
+import { useNavigation } from "@react-navigation/native";
 import { useAppDispatch, useAppSelector } from "../../../../../store";
 import { setSetting } from "../../../../slices/settings/settingsActions";
 import { selectSettings } from "../../../../slices/settings/settingsSlice";
@@ -15,15 +16,38 @@ function GeneralSettingsScreen() {
   const settings = useAppSelector(selectSettings);
 
   const { t } = useTranslation();
+  const navigation = useNavigation();
   const dispatch = useAppDispatch();
   const theme = useTheme();
+
+  const bla = settings.swipeToVote;
+  const [swipeToVoteBuffer, setSwipeToVoteBuffer] = useState<boolean>(bla);
+  useEffect(() => console.log(swipeToVoteBuffer), [swipeToVoteBuffer]);
 
   const onChange = (key: string, value: any) => {
     dispatch(setSetting({ [key]: value }));
   };
 
+  const onNavigationBlur = () => {
+    onChange("swipeToVote", swipeToVoteBuffer);
+  };
+
+  useEffect(() => {
+    navigation.addListener("blur", onNavigationBlur);
+    navigation
+      .getParent("SettingsStackNavigator")
+      ?.addListener("blur", onNavigationBlur);
+
+    return () => {
+      navigation.addListener("blur", onNavigationBlur);
+      navigation
+        .getParent("SettingsStackNavigator")
+        ?.removeListener("blur", onNavigationBlur);
+    };
+  }, [navigation, swipeToVoteBuffer]);
+
   return (
-    <ScrollView backgroundColor={theme.colors.app.bg} flex={1}>
+    <ScrollView backgroundColor={theme.colors.app.bg} flex={1} on>
       <TableView style={styles.table}>
         <CSection
           header={t("settings.appearance.gestures.header")}
@@ -44,14 +68,14 @@ function GeneralSettingsScreen() {
           />
           <CCell
             cellStyle="Basic"
-            title="Swipe to Vote"
+            title={t("settings.swipeToVote")}
             backgroundColor={theme.colors.app.fg}
             titleTextColor={theme.colors.app.textPrimary}
             rightDetailColor={theme.colors.app.textSecondary}
             cellAccessoryView={
               <Switch
-                value={settings.swipeToVote}
-                onValueChange={(v) => onChange("swipeToVote", v)}
+                value={swipeToVoteBuffer}
+                onValueChange={(v) => setSwipeToVoteBuffer(v)}
               />
             }
           />

--- a/src/plugins/i18n/locales/de.json
+++ b/src/plugins/i18n/locales/de.json
@@ -85,6 +85,7 @@
     "removedByMod": "Kommentar wurde von Moderatoren gelöscht :("
   },
   "settings": {
+    "swipeToVote": "Mit Wisch hoch-/runterwählen",
     "haptics": {
       "Off": "Keine",
       "Light": "Schwach",

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -92,6 +92,7 @@
     "removedByMod": "Comment removed by moderator :("
   },
   "settings": {
+    "swipeToVote": "Swipe to Vote",
     "haptics": {
       "Off": "Off",
       "Light": "Light",


### PR DESCRIPTION
### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [X] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [X] Your changes are free of any lint errors
- [X] Your changes are free of any typescript errors
- [X] You've tested your changes

### Summary

this fixes #810 

- fix the rerender upon swipeToVote change by buffering the change first 
- add todo notices for missing translations

### Screenshots


https://github.com/Memmy-App/memmy/assets/50131232/9295a5cc-1fe7-45fd-bf45-999727a7dbf0



### Test Plan

1. Go to `Settings` -> `Appearance`
2. Activate Swipe to Vote
3. Go to `Feed`
4. Try Voting by swiping a post -> should work
5. Go back to  `Settings` -> `Appearance`.
6. Deactivate Swipe to Vote
7. Go to `Feed` -> Can't swipe anymore but now you can use the fullscreen "go back" gesture instead

