### PR TITLE
fix sort.New translation error

### DIFF
--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -315,7 +315,7 @@
     },
     "Hot": "Hot",
     "Active": "Active",
-    "New": "Most Comments",
+    "New": "New",
     "MostComments": "Most Comments",
     "NewComments": "New Comments",
     "Old": "Old"


### PR DESCRIPTION
it was "Most Comments" but is now "New" (as it should)

fixes #872 

Unfortunately I cannot provide proof screenshots as the build is broken right now