### PR TITLE
Move browser settings into General section

### DIFF
--- a/src/components/screens/Settings/Content/ContentScreen.tsx
+++ b/src/components/screens/Settings/Content/ContentScreen.tsx
@@ -3,7 +3,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { ScrollView } from "@src/components/common/Gluestack";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { LayoutAnimation, StyleSheet, Switch } from "react-native";
+import { StyleSheet, Switch } from "react-native";
 import {
   useSettings,
   useThemeOptions,
@@ -141,24 +141,6 @@ function ContentScreen({
               <Switch
                 value={settings.hideNsfw}
                 onValueChange={(v) => onChange("hideNsfw", v)}
-              />
-            }
-          />
-        </CSection>
-        <CSection header="Web">
-          <CCell
-            cellStyle="Basic"
-            title={t("settings.content.web.useReaderMode")}
-            backgroundColor={theme.colors.fg}
-            titleTextColor={theme.colors.textPrimary}
-            rightDetailColor={theme.colors.textSecondary}
-            cellAccessoryView={
-              <Switch
-                value={settings.useReaderMode}
-                onValueChange={(v) => {
-                  LayoutAnimation.easeInEaseOut();
-                  onChange("useReaderMode", v);
-                }}
               />
             }
           />

--- a/src/components/screens/Settings/General/GeneralSettingsScreen.tsx
+++ b/src/components/screens/Settings/General/GeneralSettingsScreen.tsx
@@ -99,6 +99,20 @@ function GeneralSettingsScreen() {
               />
             }
           />
+          {!settings.useDefaultBrowser && (
+            <CCell
+              title={t("settings.general.useReaderMode")}
+              backgroundColor={theme.colors.fg}
+              titleTextColor={theme.colors.textPrimary}
+              rightDetailColor={theme.colors.textSecondary}
+              cellAccessoryView={
+                <Switch
+                  value={settings.useReaderMode}
+                  onValueChange={(v) => onChange("useReaderMode", v)}
+                />
+              }
+            />
+          )}
         </CSection>
       </TableView>
     </ScrollView>

--- a/src/plugins/i18n/locales/cz.json
+++ b/src/plugins/i18n/locales/cz.json
@@ -92,6 +92,9 @@
     "removedByMod": "Komentář byl smazán moderátorem :("
   },
   "settings": {
+    "general": {
+      "useReaderMode": "Použít čtečku"
+    },
     "reportBugBtn": "Nahlásit chybu na Github",
     "haptics": {
       "Off": "Vypnuto",
@@ -104,9 +107,6 @@
         "footer": "Tyto nastavení nijak neovlivní tvoje NSFW nastavení na tvém účtu. Toto nastavení se projeví pouze lokálně v aplikaci (globálně pro všechny účty).",
         "blur": "Rozmazat NSFW Obsah",
         "hide": "Schovat NSFW Obsah"
-      },
-      "web": {
-        "useReaderMode": "Použít čtečku"
       },
       "markRead": {
         "header": "NASTAVENÍ OZNAČOVANÍ JAKO PŘEČTENO",

--- a/src/plugins/i18n/locales/de.json
+++ b/src/plugins/i18n/locales/de.json
@@ -91,6 +91,9 @@
     "removedByMod": "Kommentar wurde von Moderatoren gelöscht :("
   },
   "settings": {
+    "general": {
+      "useReaderMode": "Lesemodus verwenden"
+    },
     "reportBugBtn": "Bug auf GitHub melden",
     "swipeToVote": "Mit Wisch hoch-/runterwählen",
     "haptics": {
@@ -104,9 +107,6 @@
         "footer": "Diese Einstellungen haben kein Einfluss auf die NSFW-Einstellungen deines Lemmy-Kontos. Diese Einstellungen werden lediglich lokal in der Memmy-App verwendet (über alle Accounts hinweg).",
         "blur": "NSFW-Inhalt verwischen/trüben",
         "hide": "NSFW-Inhalt ausblenden"
-      },
-      "web": {
-        "useReaderMode": "Lesemodus verwenden"
       },
       "markRead": {
         "header": "Als gelesen markieren",

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -98,6 +98,9 @@
     "removedByMod": "Comment removed by moderator :("
   },
   "settings": {
+    "general": {
+      "useReaderMode": "Use Reader Mode"
+    },
     "reportBugBtn": "Report a Bug on GitHub",
 		"swipeToVote": "Swipe to Vote",
     "haptics": {
@@ -111,9 +114,6 @@
         "footer": "These settings do not affect your Lemmy account NSFW settings. These setting will only apply to the local app (globally on all accounts).",
         "blur": "Blur NSFW Content",
         "hide": "Hide NSFW Content"
-      },
-      "web": {
-        "useReaderMode": "Use Reader Mode"
       },
       "markRead": {
         "header": "MARK READ SETTINGS",

--- a/src/plugins/i18n/locales/pt_br.json
+++ b/src/plugins/i18n/locales/pt_br.json
@@ -92,6 +92,9 @@
     "removedByMod": "Comentário removido pelo moderador :("
   },
   "settings": {
+    "general": {
+      "useReaderMode": "Utilizar leitor"
+    },
     "reportBugBtn": "Relatar um bug no Github",
     "haptics": {
       "Off": "Desligado",
@@ -104,9 +107,6 @@
         "footer": "Estas configurações não afetam as opções de conteúdo explícito da sua conta Lemmy, apenas ao aplicativo e todas as contas logadas nele.",
         "blur": "Desfoque conteúdo explícito",
         "hide": "Oculte conteúdo explícito"
-      },
-      "web": {
-        "useReaderMode": "Utilizar leitor"
       },
       "markRead": {
         "header": "Opções do Contéudo Lido",

--- a/src/plugins/i18n/locales/ro.json
+++ b/src/plugins/i18n/locales/ro.json
@@ -92,6 +92,9 @@
       "removedByMod": "Comentariu șters de moderator :("
     },
     "settings": {
+      "general": {
+        "useReaderMode": "Utilizați modul pentru cititor digital"
+      },
       "reportBugBtn": "Raportați o eroare pe Github",
       "haptics": {
         "Off": "Oprit",
@@ -104,9 +107,6 @@
           "footer": "Aceste setări nu afectează setările NSFW ale contului tău Lemmy. Aceste setări se vor aplica doar aplicației locale (la nivel global pe toate conturile).",
           "blur": "Blurează Continutul NSFW",
           "hide": "Ascunde Continutul NSFW"
-        },
-        "web": {
-          "useReaderMode": "Utilizați modul pentru cititor digital"
         },
         "markRead": {
           "header": "MARK READ SETTINGS",


### PR DESCRIPTION
### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [x] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [x] Your changes are free of any typescript errors
- [x] You've tested your changes

### Summary

Moves the option to open internal web links in reader mode to the General section where the option to use Default Browser is. Also hides the option when internal browser is not being used.

### Screenshots

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-28 at 15 59 52](https://github.com/Memmy-App/memmy/assets/900542/e2728946-0694-434b-b593-57279e344978)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-28 at 16 00 01](https://github.com/Memmy-App/memmy/assets/900542/44082fc7-631c-4ae1-83d1-b2947bdd96cb)


