### PR TITLE
Fix sort.top.Week using wrong label (sort.top.Hour)

### DIFF
--- a/src/hooks/contextMenu/useFeedSortOptions.ts
+++ b/src/hooks/contextMenu/useFeedSortOptions.ts
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ContextMenuOption } from "../../types/ContextMenuOptions";
-import { ICON_MAP } from "../../constants/IconMap";
+import { useTopSortOptions } from "@src/hooks/contextMenu/useTopSortOptions";
+import { ContextMenuOption } from "@src/types/ContextMenuOptions";
+import { ICON_MAP } from "@src/constants/IconMap";
 
 export const useFeedSortOptions = () => {
   const { t } = useTranslation();
@@ -44,56 +45,6 @@ export const useFeedSortOptions = () => {
         key: "Old",
         title: t("sort.Old"),
         icon: ICON_MAP.HOURGLASS,
-      },
-    ],
-    [t]
-  );
-};
-
-export const useTopSortOptions = () => {
-  const { t } = useTranslation();
-
-  return useMemo<ContextMenuOption[]>(
-    () => [
-      {
-        key: "TopHour",
-        title: t("sort.top.Hour"),
-        icon: ICON_MAP.CLOCK,
-      },
-      {
-        key: "TopSixHour",
-        title: t("sort.top.SixHours"),
-        icon: ICON_MAP.CLOCK,
-      },
-      {
-        key: "TopTwelveHour",
-        title: t("sort.top.TwelveHours"),
-        icon: ICON_MAP.CLOCK,
-      },
-      {
-        key: "TopDay",
-        title: t("sort.top.Day"),
-        icon: ICON_MAP.CLOCK,
-      },
-      {
-        key: "TopWeek",
-        title: t("sort.top.Hour"),
-        icon: ICON_MAP.CALENDAR,
-      },
-      {
-        key: "TopMonth",
-        title: t("sort.top.Month"),
-        icon: ICON_MAP.CALENDAR,
-      },
-      {
-        key: "TopYear",
-        title: t("sort.top.Year"),
-        icon: ICON_MAP.CALENDAR,
-      },
-      {
-        key: "TopAll",
-        title: t("sort.top.AllTime"),
-        icon: ICON_MAP.TROPHY,
       },
     ],
     [t]

--- a/src/hooks/contextMenu/useTopSortOptions.ts
+++ b/src/hooks/contextMenu/useTopSortOptions.ts
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+import { useMemo } from "react";
+import { ContextMenuOption } from "@src/types/ContextMenuOptions";
+import { ICON_MAP } from "@src/constants/IconMap";
+
+export const useTopSortOptions = () => {
+  const { t } = useTranslation();
+
+  return useMemo<ContextMenuOption[]>(
+    () => [
+      {
+        key: "TopHour",
+        title: t("sort.top.Hour"),
+        icon: ICON_MAP.CLOCK,
+      },
+      {
+        key: "TopSixHour",
+        title: t("sort.top.SixHours"),
+        icon: ICON_MAP.CLOCK,
+      },
+      {
+        key: "TopTwelveHour",
+        title: t("sort.top.TwelveHours"),
+        icon: ICON_MAP.CLOCK,
+      },
+      {
+        key: "TopDay",
+        title: t("sort.top.Day"),
+        icon: ICON_MAP.CLOCK,
+      },
+      {
+        key: "TopWeek",
+        title: t("sort.top.Week"),
+        icon: ICON_MAP.CALENDAR,
+      },
+      {
+        key: "TopMonth",
+        title: t("sort.top.Month"),
+        icon: ICON_MAP.CALENDAR,
+      },
+      {
+        key: "TopYear",
+        title: t("sort.top.Year"),
+        icon: ICON_MAP.CALENDAR,
+      },
+      {
+        key: "TopAll",
+        title: t("sort.top.AllTime"),
+        icon: ICON_MAP.TROPHY,
+      },
+    ],
+    [t]
+  );
+};


### PR DESCRIPTION
### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [x] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [x] Your changes are free of any typescript errors
- [x] You've tested your changes

### Summary

fixes a wrong `top week` label in the feed sort options

### Screenshots

Unfortunately I can't test it cause of this error:
![image](https://github.com/Memmy-App/memmy/assets/50131232/4e783f49-1c16-4aab-95b8-867bd47d3cc2)

### Test Plan

Take a look at the resolved comments it was quite the easy fix

