### PR TITLE
added a switch to hide posts made by bot accounts and filtered out po…

### DIFF
--- a/src/components/screens/Settings/Content/ContentScreen.tsx
+++ b/src/components/screens/Settings/Content/ContentScreen.tsx
@@ -145,6 +145,24 @@ function ContentScreen({
             }
           />
         </CSection>
+        <CSection
+          header={t("Bot Content")}
+          footer={t("settings.content.botContent.footer")}
+        >
+          <CCell
+            cellStyle="RightDetail"
+            title={t("Hide Bot Content")}
+            backgroundColor={theme.colors.fg}
+            titleTextColor={theme.colors.textPrimary}
+            rightDetailColor={theme.colors.textSecondary}
+            cellAccessoryView={
+              <Switch
+                value={settings.hideBotContent}
+                onValueChange={(v) => onChange("hideBotContent", v)}
+              />
+            }
+          />
+        </CSection>
       </TableView>
     </ScrollView>
   );

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -127,6 +127,9 @@
 				"blur": "Blur NSFW Content",
 				"hide": "Hide NSFW Content"
 			},
+			"botContent": { 
+				"footer": "Hide all posts that are made from bot accounts"
+			},
 			"markRead": {
 				"header": "MARK READ SETTINGS",
 				"onPostOpen": "Mark Read on Post Open",

--- a/src/stores/feeds/actions/setFeedPosts.ts
+++ b/src/stores/feeds/actions/setFeedPosts.ts
@@ -3,10 +3,14 @@ import { useSettingsStore } from "@src/stores/settings/settingsStore";
 import { useFeedsStore } from "../feedsStore";
 
 const setFeedPosts = (feedKey: string, posts: PostView[]) => {
-  const { hideNsfw } = useSettingsStore.getState().settings;
+  const { hideNsfw, hideBotContent } = useSettingsStore.getState().settings;
 
   if (hideNsfw) {
     posts = posts.filter((p) => !p.post.nsfw && !p.community.nsfw);
+  }
+
+  if (hideBotContent) {
+    posts = posts.filter((p) => !p.creator.bot_account);
   }
 
   useFeedsStore.setState((state) => {

--- a/src/stores/settings/settingsStore.ts
+++ b/src/stores/settings/settingsStore.ts
@@ -60,6 +60,7 @@ export interface SettingsState {
   commentSwipeLeftSecond: "Reply" | "Save" | "Collapse" | "None";
   showCommentJumpButton: boolean;
   commentJumpPlacement: "bottom left" | "bottom right" | "bottom center";
+  hideBotContent: boolean;
 }
 
 const initialState: SettingsState = {
@@ -108,6 +109,7 @@ const initialState: SettingsState = {
   commentSwipeLeftSecond: "None",
   showCommentJumpButton: true,
   commentJumpPlacement: "bottom right",
+  hideBotContent: false,
 };
 
 export const useSettingsStore = create(


### PR DESCRIPTION


### PR Creator Checklist

Ensure you've checked the following before submitting your PR:

- [x] You've discussed making your changes with a member of the dev team per contributing rules in the README
- [x] Your changes are free of any lint errors
- [x] Your changes are free of any typescript errors
- [x] You've tested your changes

### Summary

> Please provide a summary of what your PR does

this PR is for issue #974 

This PR adds a switch in the content section of the settings screen to allow the user to hide content made by bot accounts. 
In order to hide content from bot accounts I added a value in the store called hideBotContent, that has an initial value of false. 

When it is checked it will filter out posts who's creator is a bot_account. 

### Screenshots

> If the UI has been changed, include screenshots. 
> We will not review your PR without screenshots if they are applicable.

<img width="340" alt="Screenshot 2023-08-16 at 6 50 38" src="https://github.com/Memmy-App/memmy/assets/63677846/e5c0b7c6-2568-457d-8c02-d9f563013ea7">


### Test Plan

> Please document the steps required to test your PR

1.) In the simulator use the search function to look up a known bot account such as redditbot. 
2.) go to their profile and try to view their posts
3.) if the hide bot content option is on then none of their posts will appear on their profile



