### PR TITLE
Remove duplicate "Open Email App" in Onboarding

### DIFF
--- a/src/components/screens/Onboarding/CreateAccountScreen.tsx
+++ b/src/components/screens/Onboarding/CreateAccountScreen.tsx
@@ -237,7 +237,6 @@ function CreateAccountScreen({
               >
                 <Text>
                   {t("onboarding.openEmailAppBtn")}
-                  Open Email App
                 </Text>
               </Button>
               <Button onPress={() => setReady(true)} disabled={loading}>


### PR DESCRIPTION
### PR Creator Checklist

As this is just a small and obvious text-fix, I did not clone this repo and discussed the changes before opening this PR.
And as testing this, would require me to create a new Account, I did not test it either.

### Summary

> Please provide a summary of what your PR does

Removed the duplicate `Open Email App` on the onboarding. It seems to be a leftover.

### Screenshots

> If the UI has been changed, include screenshots. 
> We will not review your PR without screenshots if they are applicable.

Making a screenshot would require lots of unnecessary work on my side, due to the simplicity of this change.

### Test Plan

> Please documemnt the steps required to test your PR

Create an Account and have a look on the `onboarding.openEmailAppBtn`.