### PR TITLE
Giphy

### DIFF
--- a/src/components/Common/Giphy/GiphyImageButton.tsx
+++ b/src/components/Common/Giphy/GiphyImageButton.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react';
+import { IGiphySearchResult } from '@src/hooks';
+import { YStack } from 'tamagui';
+import { Image, ImageLoadEventData } from 'expo-image';
+import { Dimensions, StyleSheet } from 'react-native';
+import { IDimensions } from 'expo-image-viewer/src/types';
+
+interface IProps {
+  result: IGiphySearchResult;
+}
+
+const { height: WINDOW_HEIGHT, width: WINDOW_WIDTH } = Dimensions.get('window');
+
+const resizeImage = (dimensions: IDimensions): IDimensions => {
+  const widthRatio = (WINDOW_WIDTH * 0.5) / dimensions.width;
+  const heightRatio = WINDOW_HEIGHT / dimensions.height;
+
+  const ratio = Math.min(widthRatio, heightRatio);
+
+  return {
+    width: dimensions.width * ratio - 12,
+    height: dimensions.height * ratio,
+  };
+};
+
+export default function GiphyImageButton({
+  result,
+}: IProps): React.JSX.Element {
+  const [dimensions, setDimensions] = useState({
+    width: WINDOW_WIDTH / 2,
+    height: 200,
+  });
+
+  const onImageLoad = useCallback((e: ImageLoadEventData) => {
+    setDimensions(
+      resizeImage({
+        width: e.source.width,
+        height: e.source.height,
+      }),
+    );
+  }, []);
+
+  return (
+    <YStack
+      borderRadius={10}
+      alignItems="center"
+      justifyContent="center"
+      margin={3}
+    >
+      <Image
+        source={result.proxyUrl}
+        style={[styles.image, dimensions]}
+        cachePolicy="none"
+        onLoad={onImageLoad}
+        contentFit="cover"
+      />
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    borderRadius: 10,
+  },
+});

--- a/src/components/Common/Giphy/GiphyModal.tsx
+++ b/src/components/Common/Giphy/GiphyModal.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { INavigationProps } from '@src/types';
+import { YStack } from 'tamagui';
+import { IGiphySearchResult, useGiphySearch } from '@hooks/useGiphySearch';
+import HeaderSearchBar from '@components/Common/HeaderSearchBar/HeaderSearchBar';
+import GiphyImageButton from '@components/Common/Giphy/GiphyImageButton';
+import { ListRenderItemInfo, MasonryFlashList } from '@shopify/flash-list';
+import { Dimensions } from 'react-native';
+
+const renderItem = ({
+  item,
+}: ListRenderItemInfo<IGiphySearchResult>): React.JSX.Element => {
+  return <GiphyImageButton result={item} />;
+};
+
+const SCREEN_WIDTH = Dimensions.get('screen').width;
+
+const keyExtractor = (item: IGiphySearchResult): string => item.url;
+export default function GiphyModal({
+  navigation,
+}: INavigationProps): React.JSX.Element {
+  const giphySearch = useGiphySearch();
+
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (giphySearch.state.term === '') return;
+
+    navigation.setOptions({
+      headerTitle: `"${giphySearch.state.term}"`,
+    });
+  }, [giphySearch.state.term]);
+
+  const onSubmit = useCallback(() => {
+    void giphySearch.search(query);
+  }, [query]);
+
+  return (
+    <YStack flex={1}>
+      <MasonryFlashList
+        data={giphySearch.state.data}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={
+          <HeaderSearchBar onChange={setQuery} onSearch={onSubmit} />
+        }
+        numColumns={2}
+        estimatedItemSize={SCREEN_WIDTH / 2}
+        contentContainerStyle={{
+          paddingBottom: 50,
+        }}
+      />
+    </YStack>
+  );
+}

--- a/src/components/Common/Keyboard/KeyboardAccesoryView.tsx
+++ b/src/components/Common/Keyboard/KeyboardAccesoryView.tsx
@@ -1,15 +1,29 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { InputAccessoryView } from 'react-native';
 import AnimatedIconButton from '@components/Common/Button/AnimatedIconButton';
-import { Bold, Camera, Italic, Link, Quote } from '@tamagui/lucide-icons';
+import {
+  Bold,
+  Camera,
+  Italic,
+  Link,
+  Quote,
+  Video,
+} from '@tamagui/lucide-icons';
 import { useKeyboardAccessory, UseKeyboardAccessoryOptions } from '@src/hooks';
 import { XStack } from 'tamagui';
 import LoadingOverlay from '@components/Common/Loading/LoadingOverlay';
+import { useNavigation } from '@react-navigation/core';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 export default function KeyboardAccessoryView(
   params: UseKeyboardAccessoryOptions,
 ): React.JSX.Element {
+  const navigation = useNavigation<NativeStackNavigationProp<any>>();
   const accessory = useKeyboardAccessory(params);
+
+  const onGifPress = useCallback(() => {
+    navigation.push('Giphy');
+  }, []);
 
   return (
     <InputAccessoryView nativeID="accessory">
@@ -44,6 +58,12 @@ export default function KeyboardAccessoryView(
           iconSize={20}
           color="$accent"
           onPress={accessory.onQuotePress}
+        />
+        <AnimatedIconButton
+          icon={Video}
+          iconSize={20}
+          color="$accent"
+          onPress={onGifPress}
         />
         <AnimatedIconButton
           icon={Camera}

--- a/src/components/Navigation/MainScreens.tsx
+++ b/src/components/Navigation/MainScreens.tsx
@@ -21,6 +21,7 @@ import EditReplyScreen from '@components/Reply/screens/EditReplyScreen';
 import CommunityModeratorListScreen from '@components/Community/screens/CommunityModeratorListScreen';
 import CommunityInfoScreen from '@components/Community/screens/CommunityInfoScreen';
 import SavedPostsScreen from '@components/Profile/screens/SavedPostsScreen';
+import GiphyModal from '@components/Common/Giphy/GiphyModal';
 
 export default function MainScreens(
   stack: TypedNavigator<
@@ -76,6 +77,11 @@ export default function MainScreens(
           name="Reply"
           component={ReplyScreen}
           options={{ gestureEnabled: false }}
+        />
+        <stack.Screen
+          name="Giphy"
+          component={GiphyModal}
+          options={{ headerTitle: 'Giphy' }}
         />
         <stack.Screen
           name="NewPost"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useThemeSettings';
 export * from './comments';
 export * from './useBackgroundChecks';
 export * from './useManageBackgroundColor';
+export * from './useGiphySearch';

--- a/src/hooks/useGiphySearch.ts
+++ b/src/hooks/useGiphySearch.ts
@@ -1,0 +1,93 @@
+import { useReducer } from 'react';
+
+const API_URL = __DEV__
+  ? process.env.EXPO_PUBLIC_TEST_API
+  : process.env.EXPO_PUBLIC_LIVE_API;
+
+interface IGiphySearchState {
+  data: IGiphySearchResult[];
+  term: string;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+interface IAction {
+  type: 'setLoading' | 'setData' | 'setError';
+  payload?: any;
+}
+
+export interface IGiphySearchResult {
+  url: string;
+  proxyUrl: string;
+}
+
+const initialState = {
+  data: [],
+  term: '',
+  isLoading: false,
+  isError: false,
+};
+
+interface UseGiphySearch {
+  state: IGiphySearchState;
+  search: (term: string) => Promise<void>;
+  getTrending: () => Promise<void>;
+}
+
+export const useGiphySearch = (): UseGiphySearch => {
+  const [state, dispatch] = useReducer(
+    (state: IGiphySearchState, action: IAction) => {
+      switch (action.type) {
+        case 'setLoading':
+          return {
+            ...state,
+            isLoading: true,
+            isError: false,
+            term: action.payload,
+          };
+        case 'setData':
+          return {
+            ...state,
+            isLoading: false,
+            isError: false,
+            data: action.payload,
+          };
+        case 'setError':
+          return { ...state, isLoading: false, isError: true };
+        default:
+          throw new Error();
+      }
+    },
+    initialState,
+  );
+
+  const search = async (term: string): Promise<void> => {
+    if (term === '') return;
+
+    dispatch({ type: 'setLoading', payload: term });
+
+    try {
+      const response = await fetch(
+        `${API_URL}/giphy/search?term=${encodeURIComponent(term)}`,
+      );
+      const data = await response.json();
+      dispatch({ type: 'setData', payload: data });
+    } catch (error) {
+      dispatch({ type: 'setError' });
+    }
+  };
+
+  const getTrending = async (): Promise<void> => {
+    dispatch({ type: 'setLoading', payload: '' });
+
+    try {
+      const response = await fetch(`${API_URL}/trending`);
+      const data = await response.json();
+      dispatch({ type: 'setData', payload: data });
+    } catch (error) {
+      dispatch({ type: 'setError' });
+    }
+  };
+
+  return { state, search, getTrending };
+};

--- a/src/hooks/useNotificationsSetup.ts
+++ b/src/hooks/useNotificationsSetup.ts
@@ -66,7 +66,7 @@ export const useNotificationsSetup = (): UseNotifications => {
     }
 
     try {
-      const res = await axios.post(`${API_URL}/${action}`, {
+      const res = await axios.post(`${API_URL}/account/push${action}`, {
         instance: account.instance,
         authToken: accessToken,
         pushToken: token,


### PR DESCRIPTION
Add GIFs to comments and posts with Giphy.

- Not using Giphy SDK. Phones home too much data to Giphy (Meta)
- Not allowing client to interact with Giphy API directly (same reason)

How it works:

1. User submits a Giphy query to Memmy API
2. Memmy API submits the search query.
3. Memmy API returns to the client the direct URL to each image and a proxied URL to each image.
4. The client displays the results to the user through the proxied URL.
5. User selects the image they want to add to the comment/post.
6. The direct URL to the image is added to the comment/post.
7. For one hour, Memmy will - on the user's device - replace the direct Giphy URL with a proxied URL.

This should prevent any peculiar tracking done by Meta. Maybe a bit over the top, but whatever.